### PR TITLE
Add Cache-Control headers to assets uploaded to S3

### DIFF
--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -17,6 +17,8 @@ var request = require('request');
 
 var S3 = require('./s3');
 
+const ONE_YEAR_IN_SECONDS = 31536000;
+
 /*
 var CONTENT_BUCKET_URI = '//'+env.AMAZON_S3_BUCKET+'.s3.amazonaws.com/';
 var CONTENT_BUCKET_FOLDER = 'content';*/
@@ -233,7 +235,7 @@ AssetProcessor.prototype.uploadJavaScriptToCdn = function(excludeSourceMap, call
                 'Content-Type':      'application/x-javascript',
                 'Content-Encoding':  'gzip',
                 'Content-Length':    gzip.length,
-                'Cache-Control':     'max-age=31536000' //one year
+                'Cache-Control':     'public, max-age=' + ONE_YEAR_IN_SECONDS
             };
             self.emit('minifyEnded', {type: 'js', files: jsFiles});
             self.emit('uploadStarted', {type: 'js', target: targetPath, source: 'memory'});
@@ -301,7 +303,7 @@ AssetProcessor.prototype.uploadCssToCdn = function(callback) {
                 'Content-Type':      'text/css',
                 'Content-Encoding':  'gzip',
                 'Content-Length':    gzip.length,
-                'Cache-Control':     'max-age=31536000' //one year
+                'Cache-Control':     'public, max-age=' + ONE_YEAR_IN_SECONDS
             };
 
             self.emit('minifyEnded', {type: 'css', files: cssFiles});
@@ -473,7 +475,7 @@ function _uploadRelativeToRoot(files, activeRoot, targetFolder, s3, callback) {
         var target = targetFolder+'/'+_stripRoot(file, activeRoot);
         var headers = {
             'x-amz-acl':     'public-read',
-            'Cache-Control': 'max-age=1800' //30 minutes
+            'Cache-Control': 'public, max-age=' + ONE_YEAR_IN_SECONDS
         };
         eventEmitter.emit('uploadStarted', {target: target, source: file});
         s3.putFile(file, target, headers, function(err, result) {

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -18,6 +18,8 @@ var request = require('request');
 var S3 = require('./s3');
 
 const ONE_YEAR_IN_SECONDS = 31536000;
+const THIRTY_DAYS_IN_SECONDS = 2592000;
+const SEVEN_DAYS_IN_SECONDS = 604800;
 
 /*
 var CONTENT_BUCKET_URI = '//'+env.AMAZON_S3_BUCKET+'.s3.amazonaws.com/';
@@ -475,7 +477,7 @@ function _uploadRelativeToRoot(files, activeRoot, targetFolder, s3, callback) {
         var target = targetFolder+'/'+_stripRoot(file, activeRoot);
         var headers = {
             'x-amz-acl':     'public-read',
-            'Cache-Control': 'public, max-age=' + ONE_YEAR_IN_SECONDS
+            'Cache-Control': 'public, max-age=' + SEVEN_DAYS_IN_SECONDS
         };
         eventEmitter.emit('uploadStarted', {target: target, source: file});
         s3.putFile(file, target, headers, function(err, result) {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -6,6 +6,8 @@ var path    = require('path');
 var knox    = require('knox');
 var mime    = require('mime');
 
+const THIRTY_DAYS_IN_SECONDS = 2592000;
+
 // Set up our custom mime times for fonts
 mime.define({
     'application/x-font-opentype': ['otf','eot','ttf'],
@@ -140,7 +142,9 @@ S3.prototype.urlWithBucket = function(path) {
         : 'https://s3.amazonaws.com/'+this.bucket.toLowerCase()+'/'+path;
 };
 
-function _createHeaders(makePrivateOrHeaders, targetPath) {
+function _createHeaders(makePrivateOrHeaders, targetPath, timeToCacheInSeconds) {
+
+    timeToCacheInSeconds = timeToCacheInSeconds || THIRTY_DAYS_IN_SECONDS;
 
     var headers = {};
     var contentType = targetPath && mime.lookup(targetPath);
@@ -155,7 +159,7 @@ function _createHeaders(makePrivateOrHeaders, targetPath) {
         headers['Content-Type'] = contentType;
     }
 
-    headers['Cache-Control'] = 'public, max-age=604800';
+    headers['Cache-Control'] = 'public, max-age=' + timeToCacheInSeconds;
 
     return headers;
 }

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -155,6 +155,8 @@ function _createHeaders(makePrivateOrHeaders, targetPath) {
         headers['Content-Type'] = contentType;
     }
 
+    headers['Cache-Control'] = 'public, max-age=604800';
+
     return headers;
 }
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -6,8 +6,6 @@ var path    = require('path');
 var knox    = require('knox');
 var mime    = require('mime');
 
-const THIRTY_DAYS_IN_SECONDS = 2592000;
-
 // Set up our custom mime times for fonts
 mime.define({
     'application/x-font-opentype': ['otf','eot','ttf'],
@@ -142,9 +140,7 @@ S3.prototype.urlWithBucket = function(path) {
         : 'https://s3.amazonaws.com/'+this.bucket.toLowerCase()+'/'+path;
 };
 
-function _createHeaders(makePrivateOrHeaders, targetPath, timeToCacheInSeconds) {
-
-    timeToCacheInSeconds = timeToCacheInSeconds || THIRTY_DAYS_IN_SECONDS;
+function _createHeaders(makePrivateOrHeaders, targetPath) {
 
     var headers = {};
     var contentType = targetPath && mime.lookup(targetPath);
@@ -158,8 +154,6 @@ function _createHeaders(makePrivateOrHeaders, targetPath, timeToCacheInSeconds) 
     if (!headers['Content-Type'] && contentType) {
         headers['Content-Type'] = contentType;
     }
-
-    headers['Cache-Control'] = 'public, max-age=' + timeToCacheInSeconds;
 
     return headers;
 }


### PR DESCRIPTION
Hey Team,

This is part of a BusOps task to speed our core sites to support best quality scores in Google SEO and Adwords and will likely save us many tens of thousands of dollars a year.

I've added a Cache-Control header to all S3 assets:

- **privacy** = public (can be cached anywhere between cloudfront and the user)
- **max-age** = 7 days in seconds