### PR TITLE
Allow JS files to be blank

### DIFF
--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -222,7 +222,12 @@ AssetProcessor.prototype.uploadJavaScriptToCdn = function(excludeSourceMap, call
             let err;
             const mapPath = results.getPath.replace('.js','.map');
             const uglifyOptions = excludeSourceMap ? {} : {outSourceMap: self.s3.urlWithBucket(mapPath)};
+
             self.emit('minifyStarted', {type: 'js', files: jsFiles});
+
+            if (!jsFiles.length) {
+                next(null, {});
+            }
 
             try {
                 uglifyResult = uglifyjs.minify(jsFiles, uglifyOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-processor",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "start": "node process.js",
     "test": "./node_modules/.bin/nodeunit"


### PR DESCRIPTION
## Problem
If you try to run asset processor without JS files you get the following error:

![image](https://user-images.githubusercontent.com/6232226/30834386-eaa2b19c-a220-11e7-9d2a-0f524e53401b.png)
