### PR TITLE
Allow using local paths in css

### DIFF
--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -220,7 +220,8 @@ AssetProcessor.prototype.processJavaScript = function(excludeSourceMap, callback
             let uglifyResult = {};
             let err;
             const mapPath = results.getPath.replace('.js','.map');
-            const uglifyOptions = excludeSourceMap ? {} : {outSourceMap: self.s3.urlWithBucket(mapPath)};
+            const publicMapPath = self.s3 ? self.s3.urlWithBucket(mapPath) : mapPath;
+            const uglifyOptions = excludeSourceMap ? {} : {outSourceMap: publicMapPath};
 
             self.emit('minifyStarted', {type: 'js', files: jsFiles});
 
@@ -1126,7 +1127,13 @@ function _rebaseUrls(self, file, css) {
             // the asset path will either be absolute location from the root, or relative to the file
             assetPath = absoluteUrlRegex.test(normalizedUrl) ? path.join(activeSourceRoot, normalizedUrl) : path.resolve(path.dirname(file), normalizedUrl);
             if (assetPath.indexOf(activeSourceRoot) === 0) {
-                rebasedUrl = self.s3.urlWithBucket(path.join(activeRebaseRoot, assetPath.substr(activeSourceRoot.length)));
+
+                if (self.s3) {
+                    rebasedUrl = self.s3.urlWithBucket(path.join(activeRebaseRoot, assetPath.substr(activeSourceRoot.length)));
+                } else {
+                    rebasedUrl = path.join(activeRebaseRoot, assetPath.substr(activeSourceRoot.length));
+                }
+
                 // replace url with rebased one we do so by splicing out match and splicing in url; replacement functions could inadvertently replace repeat urls
                 css = css.substr(0, startIndex)+rebasedUrl+css.substr(endIndex);
                 // since we've modified the string, indexes may have change. have regex resume searching at end of replaced url

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -27,7 +27,10 @@ function S3(bucket, key, secret) {
         bucket: bucket
     };
     this.bucket = bucket;
-    this.client = knox.createClient(config);
+
+    if (bucket && key && secret) {
+        this.client = knox.createClient(config);
+    }
 }
 
 /**

--- a/process.js
+++ b/process.js
@@ -27,6 +27,10 @@ if (args.f || args.force) {
     config.forceCdnUpdate = true;
 }
 
+if (!args.r && !args.rebaseurls) {
+    delete config.s3;
+}
+
 assetProcessor = new AssetProcessor(config);
 
 // Lets always output results of checking for changes

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -4,8 +4,7 @@ require('dotenv').config();
 
 const _ = require('underscore');
 const path = require('path');
-const fsExtra = require('fs-extra');
-const fs = require('fs');
+const fs = require('fs-extra');
 const request = require('request');
 const zlib = require('zlib');
 const NodeunitAsync = require('nodeunit-async');
@@ -167,8 +166,8 @@ exports.testCompileLessFiles = function(test) {
     test.expect(2);
 
     filesToCreate.forEach(function(file) {
-        fsExtra.copySync(file, file+'.deleted');
-        fsExtra.unlinkSync(file);
+        fs.copySync(file, file+'.deleted');
+        fs.unlinkSync(file);
     });
 
     th.runTest(test, {
@@ -187,9 +186,9 @@ exports.testCompileLessFiles = function(test) {
             //TODO: modify nodeunit async to have a per-test teardown; otherwise failure here could screw thing up
             filesToCreate.forEach(function(file) {
                 const deletedPath = file+'.deleted';
-                if (fsExtra.existsSync(deletedPath)) {
-                    fsExtra.copySync(deletedPath ,file);
-                    fsExtra.unlinkSync(deletedPath);
+                if (fs.existsSync(deletedPath)) {
+                    fs.copySync(deletedPath ,file);
+                    fs.unlinkSync(deletedPath);
                 }
             });
 
@@ -443,7 +442,7 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 
     // we will use a different configuration than other tests
     const configPath = path.resolve(__dirname, 'test-files', 'test-config-5.json');
-    const config = fsExtra.readJsonFileSync(configPath);
+    const config = fs.readJsonFileSync(configPath);
     config.root = path.normalize(path.resolve(path.dirname(configPath), config.root || '.'));
     const otherAssetProcessor = new AssetProcessor(config);
 
@@ -481,13 +480,13 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 //     }
 //
 //     // clean up any previous tests
-//     if (fsExtra.existsSync(importDir)) {
-//         fsExtra.removeSync(importDir);
+//     if (fs.existsSync(importDir)) {
+//         fs.removeSync(importDir);
 //     }
 //     // simulate existing files
-//     fsExtra.mkdirpSync(importDir);
-//     fsExtra.writeFileSync(expectedFile1, 'existing file1');
-//     fsExtra.writeFileSync(expectedFile2, 'existing file2');
+//     fs.mkdirpSync(importDir);
+//     fs.writeFileSync(expectedFile1, 'existing file1');
+//     fs.writeFileSync(expectedFile2, 'existing file2');
 //
 //     test.expect(4);
 //
@@ -496,8 +495,8 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 //             otherAssetProcessor.importLatestStylesheets(next);
 //         }],
 //         assertResult: ['uploadExtrasToCdn', function(next) {
-//             const css1 = fsExtra.existsSync(expectedFile1) && fsExtra.readFileSync(expectedFile1, 'utf8');
-//             const css2 = fsExtra.existsSync(expectedFile2) && fsExtra.readFileSync(expectedFile2, 'utf8');
+//             const css1 = fs.existsSync(expectedFile1) && fs.readFileSync(expectedFile1, 'utf8');
+//             const css2 = fs.existsSync(expectedFile2) && fs.readFileSync(expectedFile2, 'utf8');
 //
 //             test.ok(css1 && css1.length > 1000);
 //             test.ok(css1 && css1.indexOf('mapped/path/to/images/home/home-notes-dark-blue.png') > 0);
@@ -519,7 +518,7 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 function _assetProcessorForTestConfig(configFile) {
     // we will use a different configuration than other tests
     const configPath = path.resolve(__dirname, 'test-files', configFile);
-    const config = fsExtra.readJsonFileSync(configPath);
+    const config = fs.readJsonFileSync(configPath);
 
     // mix in secret credentials to hard coded configs
     config.s3 = _.extend(config.s3 || {}, credentials.s3);

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -427,7 +427,7 @@ exports.testUploadExtrasToCdnCloudfront = function(test) {
     test.expect(2);
 
     th.runTest(test, {
-        remove: [function(next) {
+        uploadExtrasToCdn: [function(next) {
             otherAssetProcessor.uploadExtrasToCdn(next);
         }],
         assertResult: ['uploadExtrasToCdn', function(next, results) {

--- a/test/test-files/test-config-5.json
+++ b/test/test-files/test-config-5.json
@@ -1,0 +1,30 @@
+{
+  "s3": {
+    "cloudfrontMapping": "dummyCfMapping"
+  },
+  "targets": {
+    "javascripts": {
+      "files": [
+        "js/js_directory_1/one.js",
+        "js/js_directory_2/two.js",
+        "js/js_directory_1/three.js"
+      ]
+    },
+    "stylesheets": {
+      "files": [
+        "css/css_directory_1/one.css",
+        "css/css_directory_2/two.css",
+        "css/css_directory_1/three.css"
+      ]
+    },
+    "images": {
+      "root": "img",
+      "directories": [
+        "."
+      ]
+    },
+    "extras": {
+      "root": "extra"
+    }
+  }
+}


### PR DESCRIPTION
## Allow using local paths in css files
This feature fixes an issue in stagehand and CiBlocks where files paths in CSS use cloudfront domains even though we intended to use local files with the `--localcdn` flag.

Currently our custom icon fonts and new images are not being displayed correctly because of this bug.