### PR TITLE
Improve url rebasing for local cdn mode

### DIFF
--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -1077,8 +1077,7 @@ function _checkRelativeToRoot(self, type, callback) {
  */
 function _rebaseUrls(self, file, css) {
 
-    let activeSourceRoot; // variable to keep track of which source root (imgRoot or extrasRoot) we will be using
-    let activeRebaseRoot; // variable to keep track of which rebase root (imgRebaseRoot or extrasRebaseRoot) we will be using
+    const cssRoot = self.config.stylesheetsRoot;
 
     let normalizedUrl; //url normalized to a file system path
     let assetPath; //full path of the asset

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -1138,8 +1138,6 @@ function _rebaseUrls(self, file, css) {
                     .replace(cssRoot, '');
             }
 
-            console.log(rebasedUrl);
-
             // replace url with rebased one we do so by splicing out match and splicing in url; replacement functions could inadvertently replace repeat urls
             css = css.substr(0, startIndex) + rebasedUrl + css.substr(endIndex);
 

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -1112,7 +1112,6 @@ function _rebaseUrls(self, file, css) {
 
             // the asset path will either be absolute location from the root, or relative to the file
             if (absoluteUrlRegex.test(normalizedUrl)) {
-                // If the path is abosolute, leave it, as it is already url safe
                 /**
                  * If the path is abosolute we can leave it as is, since it is already
                  * a web safe url. 

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -1066,8 +1066,9 @@ function _checkRelativeToRoot(self, type, callback) {
 }
 
 /**
- * Rebases urls found within url() functions of the given css file
- * We do this here instead of leveraging CleanCSS because the module didn't seem to do it right
+ * Rebases urls found within url() in our CSS to be relative to the stylesheet. This
+ * allows our assets to be properly linked no matter where they are hosted.
+ * 
  * @param {object} self the "this" scope of an AssetProcessor
  * @param {string} file the full path to the css file (used to help resolve relative paths)
  * @param {string} css the css to process
@@ -1076,10 +1077,6 @@ function _checkRelativeToRoot(self, type, callback) {
  */
 function _rebaseUrls(self, file, css) {
 
-    const imgRoot = self.config.imagesRoot; //full path to the local root for image assets
-    const imgRebaseRoot = _getImageFolder(self.config.imagesRootRelative); //relative url path to the root for rebased (remote) image assets from within S3 bucket
-    const extrasRoot = self.config.extrasRoot; //full path to the local root for extra assets
-    const extrasRebaseRoot = _getExtrasFolder(self.config.extrasRootRelative); //relative url path to the root for rebased (remote) extra assets from within S3 bucket
     let activeSourceRoot; // variable to keep track of which source root (imgRoot or extrasRoot) we will be using
     let activeRebaseRoot; // variable to keep track of which rebase root (imgRebaseRoot or extrasRebaseRoot) we will be using
 
@@ -1104,43 +1101,51 @@ function _rebaseUrls(self, file, css) {
         url = match[1];
         startIndex = match.index+match[0].indexOf(url); // we want start index of just the actual url
         endIndex = startIndex + url.length;
-        activeSourceRoot = null; // the active root of the non-rebased url
 
         // clean off any quotes from url, as they are not needed
         url = url.replace(/^['"]/, '').replace(/['"]$/, '');
 
         // we don't want to rebase any external urls, so first check for that
         if (!externalHttpRegex.test(url) && !base64Regex.test(url)) {
+
             // if here, we are referencing our own files. Lets see if its an image or something extra so we know which root to use.
             normalizedUrl = path.normalize(url);
-            if (_extensionMatch(normalizedUrl, self.config.targets.images && self.config.targets.images.extensions)) {
-                activeSourceRoot = imgRoot;
-                activeRebaseRoot = imgRebaseRoot;
-            } else {
-                activeSourceRoot = extrasRoot;
-                activeRebaseRoot = extrasRebaseRoot;
-            }
-        }
 
-        // If we have an active source root (root to which we are rebasing) we want to try to rebase
-        if (activeSourceRoot) {
             // the asset path will either be absolute location from the root, or relative to the file
-            assetPath = absoluteUrlRegex.test(normalizedUrl) ? path.join(activeSourceRoot, normalizedUrl) : path.resolve(path.dirname(file), normalizedUrl);
-            if (assetPath.indexOf(activeSourceRoot) === 0) {
-
-                if (self.s3) {
-                    rebasedUrl = self.s3.urlWithBucket(path.join(activeRebaseRoot, assetPath.substr(activeSourceRoot.length)));
-                } else {
-                    rebasedUrl = path.join(activeRebaseRoot, assetPath.substr(activeSourceRoot.length));
-                }
-
-                // replace url with rebased one we do so by splicing out match and splicing in url; replacement functions could inadvertently replace repeat urls
-                css = css.substr(0, startIndex)+rebasedUrl+css.substr(endIndex);
-                // since we've modified the string, indexes may have change. have regex resume searching at end of replaced url
-                urlRegex.lastIndex = endIndex;
+            if (absoluteUrlRegex.test(normalizedUrl)) {
+                // If the path is abosolute, leave it, as it is already url safe
+                /**
+                 * If the path is abosolute we can leave it as is, since it is already
+                 * a web safe url. 
+                 * 
+                 * -- Example --
+                 * Asset in CSS: '/images/logo.png'
+                 */
+                rebasedUrl = normalizedUrl
             } else {
-                console.warn('Cannot find expected root '+activeSourceRoot+' in asset path '+assetPath);
+                /**
+                 * If we have a relative asset in our CSS we are going to resolve it 
+                 * to its local path and then make it an absolute web path based on 
+                 * the css root path.
+                 * 
+                 * -- Example --
+                 * CSS: /app/public/stylesheet/styles.css
+                 * Asset Path in CSS: ../images/logo.png
+                 * Resolved Local Path: /app/public/images/logo.png
+                 * Resolved Web Path: /images/logo.png
+                 */
+                rebasedUrl = path
+                    .resolve(path.dirname(file), normalizedUrl)
+                    .replace(cssRoot, '');
             }
+
+            console.log(rebasedUrl);
+
+            // replace url with rebased one we do so by splicing out match and splicing in url; replacement functions could inadvertently replace repeat urls
+            css = css.substr(0, startIndex) + rebasedUrl + css.substr(endIndex);
+
+            // since we've modified the string, indexes may have change. have regex resume searching at end of replaced url
+            urlRegex.lastIndex = endIndex;
         }
     }
 

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -280,9 +280,9 @@ exports.testUploadCssToCdn = function(test) {
             test.ok(css.indexOf('.p1') < css.indexOf('.p3'));
 
             // Tests the URL Rebase
-            test.notEqual(-1, css.indexOf('url('+bucket+'/img/img_directory_1/grey_wash_wall.png)'));
-            test.notEqual(-1, css.indexOf('url('+bucket+'/img/img_directory_1/mooning.png)'));
-            test.notEqual(-1, css.indexOf('url('+bucket+'/extra/fonts/fontawesome-webfont.woff)'));
+            test.notEqual(-1, css.indexOf('url(/'+bucket+'/img/img_directory_1/grey_wash_wall.png)'));
+            test.notEqual(-1, css.indexOf('url(/'+bucket+'/img/img_directory_1/mooning.png)'));
+            test.notEqual(-1, css.indexOf('url(/'+bucket+'/extra/fonts/fontawesome-webfont.woff)'));
             test.notEqual(-1, css.indexOf('url(//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic)'));
             test.notEqual(-1, css.indexOf('url(https://themes.googleusercontent.com/static/fonts/opensans/v8/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)'));
             test.ok(css.indexOf('url(data:image/png;base64') > 0);

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -280,9 +280,9 @@ exports.testUploadCssToCdn = function(test) {
             test.ok(css.indexOf('.p1') < css.indexOf('.p3'));
 
             // Tests the URL Rebase
-            test.notEqual(-1, css.indexOf('/img/img_directory_1/grey_wash_wall.png)'));
-            test.notEqual(-1, css.indexOf('/img/img_directory_1/mooning.png)'));
-            test.notEqual(-1, css.indexOf('/extra/fonts/fontawesome-webfont.woff)'));
+            test.notEqual(-1, css.indexOf('url(/img/img_directory_1/grey_wash_wall.png)'));
+            test.notEqual(-1, css.indexOf('url(/img_directory_1/mooning.png)'));
+            test.notEqual(-1, css.indexOf('url(/extra/fonts/fontawesome-webfont.woff)'));
             test.notEqual(-1, css.indexOf('url(//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic)'));
             test.notEqual(-1, css.indexOf('url(https://themes.googleusercontent.com/static/fonts/opensans/v8/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)'));
             test.ok(css.indexOf('url(data:image/png;base64') > 0);

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -281,7 +281,7 @@ exports.testUploadCssToCdn = function(test) {
 
             // Tests the URL Rebase
             test.notEqual(-1, css.indexOf('url(/img/img_directory_1/grey_wash_wall.png)'));
-            test.notEqual(-1, css.indexOf('url(/img_directory_1/mooning.png)'));
+            test.notEqual(-1, css.indexOf('url(/img/img_directory_1/mooning.png)'));
             test.notEqual(-1, css.indexOf('url(/extra/fonts/fontawesome-webfont.woff)'));
             test.notEqual(-1, css.indexOf('url(//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic)'));
             test.notEqual(-1, css.indexOf('url(https://themes.googleusercontent.com/static/fonts/opensans/v8/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)'));

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -279,9 +279,10 @@ exports.testUploadCssToCdn = function(test) {
             test.ok(css.indexOf('.p2') < css.indexOf('.p1'));
             test.ok(css.indexOf('.p1') < css.indexOf('.p3'));
 
-            test.notEqual(-1, css.indexOf('url(https://s3.amazonaws.com/'+bucket+'/img/img_directory_1/grey_wash_wall.png)'));
-            test.notEqual(-1, css.indexOf('url(https://s3.amazonaws.com/'+bucket+'/img/img_directory_1/mooning.png)'));
-            test.notEqual(-1, css.indexOf('url(https://s3.amazonaws.com/'+bucket+'/extra/fonts/fontawesome-webfont.woff)'));
+            // Tests the URL Rebase
+            test.notEqual(-1, css.indexOf('url('+bucket+'/img/img_directory_1/grey_wash_wall.png)'));
+            test.notEqual(-1, css.indexOf('url('+bucket+'/img/img_directory_1/mooning.png)'));
+            test.notEqual(-1, css.indexOf('url('+bucket+'/extra/fonts/fontawesome-webfont.woff)'));
             test.notEqual(-1, css.indexOf('url(//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic)'));
             test.notEqual(-1, css.indexOf('url(https://themes.googleusercontent.com/static/fonts/opensans/v8/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)'));
             test.ok(css.indexOf('url(data:image/png;base64') > 0);
@@ -457,7 +458,8 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
             const cssFilePath = path.resolve(__dirname, 'test-files', 'css', results.processAssets.cssUrl.split('/').pop());
             const cssFile = fs.readFileSync(cssFilePath).toString();
 
-            test.ok(cssFile.indexOf('https://dummyCfMapping.cloudfront.net/img') >= 0);
+            // Test url rebase
+            test.ok(cssFile.indexOf('/img') >= 0);
             next();
         }]
     });

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -280,9 +280,9 @@ exports.testUploadCssToCdn = function(test) {
             test.ok(css.indexOf('.p1') < css.indexOf('.p3'));
 
             // Tests the URL Rebase
-            test.notEqual(-1, css.indexOf('url(/'+bucket+'/img/img_directory_1/grey_wash_wall.png)'));
-            test.notEqual(-1, css.indexOf('url(/'+bucket+'/img/img_directory_1/mooning.png)'));
-            test.notEqual(-1, css.indexOf('url(/'+bucket+'/extra/fonts/fontawesome-webfont.woff)'));
+            test.notEqual(-1, css.indexOf('/img/img_directory_1/grey_wash_wall.png)'));
+            test.notEqual(-1, css.indexOf('/img/img_directory_1/mooning.png)'));
+            test.notEqual(-1, css.indexOf('/extra/fonts/fontawesome-webfont.woff)'));
             test.notEqual(-1, css.indexOf('url(//fonts.googleapis.com/css?family=Roboto:400,300,500,500italic,700,900,400italic,700italic)'));
             test.notEqual(-1, css.indexOf('url(https://themes.googleusercontent.com/static/fonts/opensans/v8/MTP_ySUJH_bn48VBG8sNSnhCUOGz7vYGh680lGh-uXM.woff)'));
             test.ok(css.indexOf('url(data:image/png;base64') > 0);

--- a/test/test-files/css/css_directory_1/anywhere1.css
+++ b/test/test-files/css/css_directory_1/anywhere1.css
@@ -1,8 +1,8 @@
 /* anywhere 1 */
 .anywhere-1 {
   width: 1px;
-  background-image: url('/img_directory_1/mooning.png');
+  background-image: url('/img/img_directory_1/mooning.png');
 }
 .repeatUrl3 {
-    background-image: url('/img_directory_1/mooning.png');
+    background-image: url('/img/img_directory_1/mooning.png');
 }


### PR DESCRIPTION
This refactors the way we rebase urls with asset processor. Ultimately this fixes the issue where staging assets are hardcoded to point to prods cdn.

If we have a relative asset in our CSS we are going to resolve it to its local path and then make it an absolute web path based on the css root path.

**Example**
CSS: /app/public/stylesheet/styles.css
Asset Path in CSS: ../images/logo.png
Resolved Local Path: /app/public/images/logo.png
Resolved Web Path: /images/logo.png

This will work whether we use a CDN or serve the assets directly from the web server like we do on ciblocks and other places.

NOTE: This also fixes an issue in prod. I copied this from our live stylesheet on VB:
```
background:url(https://d3g7htsbjjywiv.cloudfront.net/app/public/assets/common/images/sort_both.png)
```

Not sure how long rebasing of urls have been broken for relative assets, but currently `/app/public` is stuck in there when it should not be.

**TODO**
- [x] Fix failing tests