### PR TITLE
Enables skipping of processing JS files

### DIFF
--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -559,6 +559,7 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
 
 /**
  * Ensures latest assets are processed and uploaded
+ * @param {object} args Args passed from the asset processor command
  * @param {function} callback function(err, results)
  * @return {object} result
  * @return {object} result.ensureJs
@@ -566,7 +567,7 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
  * @return {object} result.ensureImages
  * @return {object} result.ensureExtras
  */
-AssetProcessor.prototype.ensureAssets = function(callback) {
+AssetProcessor.prototype.ensureAssets = function(args, callback) {
 
     const self = this;
 
@@ -574,7 +575,11 @@ AssetProcessor.prototype.ensureAssets = function(callback) {
 
     async.auto({
         ensureJs: [function(next) {
-            _checkAndUpdateJavaScript(self, next);
+            if (!args['skip-js']) {
+                _checkAndUpdateJavaScript(self, next);
+            } else {
+                next();
+            }
         }],
         ensureCss: ['ensureJs', function(next) {
             _checkAndUpdateCss(self, next);
@@ -592,13 +597,17 @@ AssetProcessor.prototype.ensureAssets = function(callback) {
 
 };
 
-AssetProcessor.prototype.processAssets = function(callback) {
+AssetProcessor.prototype.processAssets = function(args, callback) {
 
     const self = this;
 
     async.auto({
         processJs: [function(next) {
-            self.saveJavaScriptToFile(next);
+            if (!args['skip-js']) {
+                self.saveJavaScriptToFile(next);
+            } else {
+                next();
+            }
         }],
         processCss: [function(next) {
             self.saveCssToFile(next);

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -570,7 +570,8 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
 AssetProcessor.prototype.ensureAssets = function(opts, callback) {
 
     if (typeof opts === 'function') {
-        callback = opts;
+        callback = _.clone(opts);
+        opts = {};
     }
 
     const self = this;
@@ -604,7 +605,8 @@ AssetProcessor.prototype.ensureAssets = function(opts, callback) {
 AssetProcessor.prototype.processAssets = function(opts, callback) {
 
     if (typeof opts === 'function') {
-        callback = opts;
+        callback = _.clone(opts);
+        opts = {};
     }
 
     const self = this;

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -560,6 +560,7 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
 /**
  * Ensures latest assets are processed and uploaded
  * @param {object} [opts] Options passed from the asset processor command
+ * @param {boolean} [opts.skipJs] If true processing JavaScript files will be skipped
  * @param {function} callback function(err, results)
  * @return {object} result
  * @return {object} result.ensureJs
@@ -602,6 +603,17 @@ AssetProcessor.prototype.ensureAssets = function(opts, callback) {
 
 };
 
+/**
+ * Processes assets and writes them to files
+ * @param {object} [opts] Options passed from the asset processor command
+ * @param {boolean} [opts.skipJs] If true processing JavaScript files will be skipped
+ * @param {function} callback function(err, results)
+ * @return {object} result
+ * @return {object} result.processJs
+ * @return {object} result.processCss
+ * @return {object} result.imagesUrl
+ * @return {object} result.extrasUrl
+ */
 AssetProcessor.prototype.processAssets = function(opts, callback) {
 
     if (typeof opts === 'function') {

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -559,7 +559,7 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
 
 /**
  * Ensures latest assets are processed and uploaded
- * @param {object} args Args passed from the asset processor command
+ * @param {object} [opts] Options passed from the asset processor command
  * @param {function} callback function(err, results)
  * @return {object} result
  * @return {object} result.ensureJs
@@ -567,7 +567,11 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
  * @return {object} result.ensureImages
  * @return {object} result.ensureExtras
  */
-AssetProcessor.prototype.ensureAssets = function(args, callback) {
+AssetProcessor.prototype.ensureAssets = function(opts, callback) {
+
+    if (typeof opts === 'function') {
+        callback = opts;
+    }
 
     const self = this;
 
@@ -575,7 +579,7 @@ AssetProcessor.prototype.ensureAssets = function(args, callback) {
 
     async.auto({
         ensureJs: [function(next) {
-            if (!args['skip-js']) {
+            if (!opts.skipJs) {
                 _checkAndUpdateJavaScript(self, next);
             } else {
                 next();
@@ -597,13 +601,17 @@ AssetProcessor.prototype.ensureAssets = function(args, callback) {
 
 };
 
-AssetProcessor.prototype.processAssets = function(args, callback) {
+AssetProcessor.prototype.processAssets = function(opts, callback) {
+
+    if (typeof opts === 'function') {
+        callback = opts;
+    }
 
     const self = this;
 
     async.auto({
         processJs: [function(next) {
-            if (!args['skip-js']) {
+            if (!opts.skipJs) {
                 self.saveJavaScriptToFile(next);
             } else {
                 next();

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -570,7 +570,7 @@ function _wrapUploadEmitter(parentEmitter, childEmitter, type) {
 AssetProcessor.prototype.ensureAssets = function(opts, callback) {
 
     if (typeof opts === 'function') {
-        callback = _.clone(opts);
+        callback = opts;
         opts = {};
     }
 
@@ -605,7 +605,7 @@ AssetProcessor.prototype.ensureAssets = function(opts, callback) {
 AssetProcessor.prototype.processAssets = function(opts, callback) {
 
     if (typeof opts === 'function') {
-        callback = _.clone(opts);
+        callback = opts;
         opts = {};
     }
 

--- a/process.js
+++ b/process.js
@@ -56,6 +56,10 @@ if (args.v || args.verbose) {
     console.log('Checking if repository is up to date');
 }
 
+const opts = {
+    skipJs: args['skip-js']
+};
+
 async.auto({
     versionUpToDate: [function(next) {
         var ignoreVersioning = args.i || args.ignore;
@@ -118,10 +122,10 @@ async.auto({
     ensureAssets: ['versionUpToDate', function(next) {
         if (args.u || args.upload) {
             console.log('Ensuring assets');
-            assetProcessor.ensureAssets(args, next);
+            assetProcessor.ensureAssets(opts, next);
         } else if (args.l || args.localcdn) {
             console.log('Processing assets and saving locally');
-            assetProcessor.processAssets(args, next);
+            assetProcessor.processAssets(opts, next);
         } else {
             next(null, {});
         }

--- a/process.js
+++ b/process.js
@@ -118,10 +118,10 @@ async.auto({
     ensureAssets: ['versionUpToDate', function(next) {
         if (args.u || args.upload) {
             console.log('Ensuring assets');
-            assetProcessor.ensureAssets(next);
+            assetProcessor.ensureAssets(args, next);
         } else if (args.l || args.localcdn) {
             console.log('Processing assets and saving locally');
-            assetProcessor.processAssets(next);
+            assetProcessor.processAssets(args, next);
         } else {
             next(null, {});
         }

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -366,7 +366,7 @@ exports.testEnsureAssets = function(test) {
 
     th.runTest(test, {
         ensureAssets: [function(next) {
-            assetProcessor.ensureAssets({}, next);
+            assetProcessor.ensureAssets(next);
         }],
         assertResult: ['ensureAssets', function(next, results) {
             const ensureResult = results.ensureAssets || {};
@@ -451,7 +451,7 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 
     th.runTest(test, {
         processAssets: [function(next) {
-            otherAssetProcessor.processAssets({}, next);
+            otherAssetProcessor.processAssets(next);
         }],
         assertResult: ['processAssets', function(next, results) {
 

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -366,7 +366,7 @@ exports.testEnsureAssets = function(test) {
 
     th.runTest(test, {
         ensureAssets: [function(next) {
-            assetProcessor.ensureAssets(next);
+            assetProcessor.ensureAssets({}, next);
         }],
         assertResult: ['ensureAssets', function(next, results) {
             const ensureResult = results.ensureAssets || {};
@@ -451,7 +451,7 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
 
     th.runTest(test, {
         processAssets: [function(next) {
-            otherAssetProcessor.processAssets(next);
+            otherAssetProcessor.processAssets({}, next);
         }],
         assertResult: ['processAssets', function(next, results) {
 


### PR DESCRIPTION
In efforts to move Stockblocks off of asset process and into webpack, we want to enable skipping processing of JS files.