### PR TITLE
[Bugfix] Fixes broken tests from test generated files not removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 
 #unit test generated files
 test/test-files/import/
+test/out/
 
 #OS stuff
 .DS_Store

--- a/lib/assetProcessor.js
+++ b/lib/assetProcessor.js
@@ -246,8 +246,9 @@ AssetProcessor.prototype.processJavaScript = function(excludeSourceMap, callback
 /**
  * Saves processed JavaScript locally
  * @param callback
+ * @param filePath
  */
-AssetProcessor.prototype.saveJavaScriptToFile = function(callback) {
+AssetProcessor.prototype.saveJavaScriptToFile = function(callback, filePath) {
 
     const self = this;
 
@@ -261,7 +262,8 @@ AssetProcessor.prototype.saveJavaScriptToFile = function(callback) {
             const source = results.getSource.minify.js;
 
             if (source) {
-                const fullLocalPath = self.config.javascriptsRoot + '/' + results.getSource.getPath;
+                const basePath = filePath ? filePath : self.config.javascriptsRoot;
+                const fullLocalPath = basePath + '/' + results.getSource.getPath;
                 relativeUrl = '/' + results.getSource.getPath;
 
                 fs.outputFileSync(fullLocalPath, source);
@@ -363,7 +365,12 @@ AssetProcessor.prototype.processCss = function(callback) {
     }, callback);
 };
 
-AssetProcessor.prototype.saveCssToFile = function(callback) {
+/**
+ * Saves processed css locally
+ * @param callback
+ * @param filePath
+ */
+AssetProcessor.prototype.saveCssToFile = function(callback, filePath) {
 
     const self = this;
 
@@ -377,7 +384,8 @@ AssetProcessor.prototype.saveCssToFile = function(callback) {
             const source = results.getSource.cleanCss;
 
             if (source) {
-                const fullLocalPath = self.config.stylesheetsRoot + '/' + results.getSource.getPath;
+                const basePath = filePath ? filePath : self.config.stylesheetsRoot;
+                const fullLocalPath = basePath + '/' + results.getSource.getPath;
                 relativeUrl = '/' + results.getSource.getPath;
 
                 fs.outputFileSync(fullLocalPath, source);
@@ -626,13 +634,13 @@ AssetProcessor.prototype.processAssets = function(opts, callback) {
     async.auto({
         processJs: [function(next) {
             if (!opts.skipJs) {
-                self.saveJavaScriptToFile(next);
+                self.saveJavaScriptToFile(next, opts.filePath);
             } else {
                 next();
             }
         }],
         processCss: [function(next) {
-            self.saveCssToFile(next);
+            self.saveCssToFile(next, opts.filePath);
         }]
     }, function(err, results) {
 

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -475,16 +475,23 @@ exports.tearDown = function(cb) {
     const jsFiles = fs.readdirSync(jsDir).filter(file => file.endsWith('.js'));
     const cssFiles = fs.readdirSync(cssDir).filter(file => file.endsWith('.css'));
 
-    jsFiles.forEach(file => {
-        fs.unlinkSync(`${jsDir}/${file}`);
-    });
-
-    cssFiles.forEach(file => {
-        fs.unlinkSync(`${cssDir}/${file}`);
-    });
+    _removeFilesFromDir(jsDir, jsFiles);
+    _removeFilesFromDir(cssDir, cssFiles);
 
     cb();
 };
+
+/**
+ * Helper function that removes files from a directory
+ * @param dir name of directory to remove files from
+ * @param files the files to remove
+ * @private
+ */
+function _removeFilesFromDir(dir, files) {
+    files.forEach(file => {
+        fs.unlinkSync(`${dir}/${file}`);
+    });
+}
 
 // NOTE: The files this is trying to pull from github do not exist anymore
 // exports.testImportLatestStylesheets = function(test) {

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -455,11 +455,18 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
         }],
         assertResult: ['processAssets', function(next, results) {
 
+            const jsFilePath = path.resolve(__dirname, 'test-files', 'js', results.processAssets.jsUrl.split('/').pop());
             const cssFilePath = path.resolve(__dirname, 'test-files', 'css', results.processAssets.cssUrl.split('/').pop());
+
             const cssFile = fs.readFileSync(cssFilePath).toString();
 
             // Test url rebase
             test.ok(cssFile.indexOf('/img') >= 0);
+
+            // Remove files generated from test
+            fs.removeSync(cssFilePath);
+            fs.removeSync(jsFilePath);
+
             next();
         }]
     });

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -455,24 +455,36 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
         }],
         assertResult: ['processAssets', function(next, results) {
 
-            const jsFilePath = path.resolve(__dirname, 'test-files', 'js', results.processAssets.jsUrl.split('/').pop());
             const cssFilePath = path.resolve(__dirname, 'test-files', 'css', results.processAssets.cssUrl.split('/').pop());
-
             const cssFile = fs.readFileSync(cssFilePath).toString();
 
             // Test url rebase
             test.ok(cssFile.indexOf('/img') >= 0);
-
-            // Remove files generated from test
-            fs.removeSync(cssFilePath);
-            fs.removeSync(jsFilePath);
-
             next();
         }]
     });
 
 };
 
+// Run after each test.
+// Cleans up any generated files from tests.
+exports.tearDown = function(cb) {
+    const jsDir = path.resolve(__dirname, 'test-files', 'js');
+    const cssDir = path.resolve(__dirname, 'test-files', 'css');
+
+    const jsFiles = fs.readdirSync(jsDir).filter(file => file.endsWith('.js'));
+    const cssFiles = fs.readdirSync(cssDir).filter(file => file.endsWith('.css'));
+
+    jsFiles.forEach(file => {
+        fs.unlinkSync(`${jsDir}/${file}`);
+    });
+
+    cssFiles.forEach(file => {
+        fs.unlinkSync(`${cssDir}/${file}`);
+    });
+
+    cb();
+};
 
 // NOTE: The files this is trying to pull from github do not exist anymore
 // exports.testImportLatestStylesheets = function(test) {

--- a/test/test-assetProcessor.js
+++ b/test/test-assetProcessor.js
@@ -446,16 +446,17 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
     const config = fs.readJsonFileSync(configPath);
     config.root = path.normalize(path.resolve(path.dirname(configPath), config.root || '.'));
     const otherAssetProcessor = new AssetProcessor(config);
+    const opts = { filePath: 'test/out' };
 
     test.expect(1);
 
     th.runTest(test, {
         processAssets: [function(next) {
-            otherAssetProcessor.processAssets(next);
+            otherAssetProcessor.processAssets(opts, next);
         }],
         assertResult: ['processAssets', function(next, results) {
 
-            const cssFilePath = path.resolve(__dirname, 'test-files', 'css', results.processAssets.cssUrl.split('/').pop());
+            const cssFilePath = path.resolve(opts.filePath, 'css', results.processAssets.cssUrl.split('/').pop());
             const cssFile = fs.readFileSync(cssFilePath).toString();
 
             // Test url rebase
@@ -465,33 +466,6 @@ exports.testUseCloudFrontWithoutS3 = function(test) {
     });
 
 };
-
-// Run after each test.
-// Cleans up any generated files from tests.
-exports.tearDown = function(cb) {
-    const jsDir = path.resolve(__dirname, 'test-files', 'js');
-    const cssDir = path.resolve(__dirname, 'test-files', 'css');
-
-    const jsFiles = fs.readdirSync(jsDir).filter(file => file.endsWith('.js'));
-    const cssFiles = fs.readdirSync(cssDir).filter(file => file.endsWith('.css'));
-
-    _removeFilesFromDir(jsDir, jsFiles);
-    _removeFilesFromDir(cssDir, cssFiles);
-
-    cb();
-};
-
-/**
- * Helper function that removes files from a directory
- * @param dir name of directory to remove files from
- * @param files the files to remove
- * @private
- */
-function _removeFilesFromDir(dir, files) {
-    files.forEach(file => {
-        fs.unlinkSync(`${dir}/${file}`);
-    });
-}
 
 // NOTE: The files this is trying to pull from github do not exist anymore
 // exports.testImportLatestStylesheets = function(test) {


### PR DESCRIPTION
The `testUseCloudFrontWithoutS3` test generates hashed output files and writes them back to the directory. 

Other tests assume there will not be any new files there. This change cleans up those files after the test is run.